### PR TITLE
Hack to change url to resources directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,7 @@ module.exports = function(content) {
   this.emitFile(url, content, false);
   this.addDependency(this.resourcePath);
 
-  if (config.basePath) {
-    var baseDir = path.relative(config.basePath, this.options.output.path);
-    url = path.join(baseDir, url);
-  }
+  url = ".\\resources\\" + url;
 
   // now we overrite the emitted file with "real" content
 


### PR DESCRIPTION
Due to decrediton's extraResource file management I've hacked this to spefically look for the node files in the `./resources/` directory.

With the addition of `"*.node"` into one's `extraResources` package.json build options this should work on any project.